### PR TITLE
Add support for ```objc code fence

### DIFF
--- a/Markdown (Github Flavored).tmLanguage
+++ b/Markdown (Github Flavored).tmLanguage
@@ -759,7 +759,7 @@
 		<key>fenced-obj-c</key>
 		<dict>
 			<key>begin</key>
-			<string>(\s*```)\s*(objective-c)\s*$</string>
+			<string>(\s*```)\s*(obj(ective-)?c)\s*$</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
When marking a code block as Objective-C the short notation `objc` is often used.
This patch makes the plugin understand both

`````` md
```objective-c
``````

and

`````` md
```objc
``````
